### PR TITLE
fix: Use craftctl to set the snap version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,9 @@ jobs:
       run: sudo ./test_snap.sh ${{ steps.snapcraft.outputs.snap }}
     - uses: actions/upload-artifact@v4
       with:
-        name: etcd.snap
+        name: snap-built-by-${{ matrix.runner }}
         path: ${{ steps.snapcraft.outputs.snap }}
     - name: Setup tmate session
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 10

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,5 +44,5 @@ parts:
     plugin: nil
     source: .
     override-prime: |
-      etcd_version=$($CRAFT_PRIME/bin/etcd --version | head -n1 | awk '{print $3}')
+      etcd_version=$($CRAFT_PRIME/bin/etcdctl version | grep -i 'etcdctl version' | awk '{print $3}')
       craftctl set version="$etcd_version"

--- a/test_snap.sh
+++ b/test_snap.sh
@@ -4,6 +4,11 @@ set -eux
 
 snapfile="$1"
 
+arch=$(dpkg --print-architecture)
+if [[ "$arch" != "amd64" ]]; then
+    export ETCD_UNSUPPORTED_ARCH="$arch"
+fi
+
 snap remove etcd
 snap install $snapfile --dangerous
 
@@ -17,5 +22,6 @@ version=$(grep source-tag: snap/snapcraft.yaml | sed 's/.*: v//')
 
 /snap/etcd/current/bin/etcdctl version | grep $version
 /snap/etcd/current/bin/etcd --version | grep $version
+echo $snapfile | grep $version
 
 snap remove etcd


### PR DESCRIPTION
### Overview
Debugging issues where the version cannot be automatically set on arm builders

### Details
* only set version based on etcd built and primed
* set version using `craftctl` 
* get version from `etcdctl` since running etcd fails to start without setting `ETCD_UNSUPPORTED_ARCH` first
* swap to using `CRAFT_*` env vars
* test on amd64 and arm64 (gh doesn't have s390x runners)